### PR TITLE
修复 Gradle Kotlin 插件配置并移除已弃用的 Bintray 仓库

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,17 @@
+buildscript {
+    ext.kotlin_version = '1.5.31'
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.20-M1'
 }
 
 apply plugin: "kotlin"
@@ -10,7 +21,6 @@ version '0.0.1-SNAPSHOT'
 
 allprojects{
     repositories {
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         mavenCentral()
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'kotlin'
 }
 
 group 'com.agmtopy'

--- a/logging/build.gradle
+++ b/logging/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'kotlin'
 }
 
 group 'com.agmtopy'

--- a/namesrv/build.gradle
+++ b/namesrv/build.gradle
@@ -1,10 +1,9 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'kotlin'
 }
 
 repositories {
-    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     mavenCentral()
 }
 

--- a/remoting/build.gradle
+++ b/remoting/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'kotlin'
 }
 
 group 'com.agmtopy'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,7 @@
 pluginManagement {
     repositories {
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
+        gradlePluginPortal()
         mavenCentral()
-        maven { url 'https://plugins.gradle.org/m2/' }
     }
 }
 rootProject.name = 'kocketmq'
@@ -10,4 +9,3 @@ include 'namesrv'
 include 'logging'
 include 'common'
 include 'remoting'
-


### PR DESCRIPTION
### Motivation
- 解决构建时 Kotlin 插件无法解析和连接到已下线的 Bintray 仓库导致的构建失败问题。 

### Description
- 在根 `build.gradle` 中替换原来的 EAP 插件标识，改为通过 `buildscript` 引入 `org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31`。 
- 移除了根、`settings.gradle` 和 `namesrv` 中对已弃用 `https://dl.bintray.com/kotlin/kotlin-eap` 的引用并改用 `mavenCentral()` 或 `gradlePluginPortal()`。 
- 将子模块中的插件声明从 `id 'org.jetbrains.kotlin.jvm'` 统一改为 `id 'kotlin'`，以配合根工程的 classpath 插件加载方式。 

### Testing
- 运行 `./gradlew build --no-daemon`（使用 wrapper）时触发远程 Gradle 下载，但请求被代理返回 `403`，构建未成功。 
- 使用本地 `gradle build --no-daemon`（未指定 JAVA_HOME）出现 `Unsupported class file major version 69`，表明运行时 Java 版本不匹配，构建未成功。 
- 在指定 `JAVA_HOME` 为 Java 17 并运行 `gradle build --no-daemon` 后，构建已能绕过原先的插件 marker 问题，但从 Maven/Plugin 仓库拉取依赖时仍受环境网络策略影响并返回 `403`，因此无法完成全部依赖解析和最终编译。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b324e2284832e8e87fbddcfe0e2af)