### PR TITLE
namesrv: implement lifecycle & housekeeping, fix KV loading, add unit tests and Gradle compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,17 @@
+buildscript {
+    ext.kotlin_version = '1.9.24'
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.20-M1'
 }
 
 apply plugin: "kotlin"
@@ -10,8 +21,15 @@ version '0.0.1-SNAPSHOT'
 
 allprojects{
     repositories {
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         mavenCentral()
+    }
+}
+
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions {
+            jvmTarget = "11"
+        }
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'kotlin'
 }
 
 group 'com.agmtopy'

--- a/logging/build.gradle
+++ b/logging/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'kotlin'
 }
 
 group 'com.agmtopy'

--- a/namesrv/build.gradle
+++ b/namesrv/build.gradle
@@ -1,10 +1,11 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'kotlin'
 }
 
+sourceCompatibility = 11
+
 repositories {
-    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     mavenCentral()
 }
 
@@ -21,4 +22,10 @@ dependencies {
     implementation "io.netty:netty-all:4.0.42.Final"
     implementation "io.netty:netty-all:4.0.42.Final"
     implementation 'com.google.guava:guava:28.2-jre'
+
+    testImplementation('org.junit.jupiter:junit-jupiter:5.5.2')
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/NamesrvController.kt
+++ b/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/NamesrvController.kt
@@ -45,7 +45,7 @@ class NamesrvController(var namesrvConfig: NamesrvConfig, var nettyServerConfig:
     init {
         kvConfigManager = KVConfigManager(this)
         routeInfoManager = RouteInfoManager()
-        brokerHousekeepingService = BrokerHousekeepingService()
+        brokerHousekeepingService = BrokerHousekeepingService(routeInfoManager)
         this.configuration = Configuration(log, arrayOf(namesrvConfig, nettyServerConfig))
         this.configuration.setStorePathFromConfig(this.namesrvConfig, "configStorePath")
     }
@@ -86,7 +86,7 @@ class NamesrvController(var namesrvConfig: NamesrvConfig, var nettyServerConfig:
 
         //7.tls相关操作
         //@TODO
-        return false
+        return true
     }
 
     /**
@@ -108,12 +108,18 @@ class NamesrvController(var namesrvConfig: NamesrvConfig, var nettyServerConfig:
      * start
      */
     fun start() {
-
+        remotingServer.start()
     }
 
     /**
      */
     fun shutdown() {
-
+        if (this::remotingServer.isInitialized) {
+            remotingServer.shutdown()
+        }
+        if (this::remotingExecutor.isInitialized) {
+            remotingExecutor.shutdown()
+        }
+        scheduledExecutorService.shutdown()
     }
 }

--- a/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/NamesrvController.kt
+++ b/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/NamesrvController.kt
@@ -4,7 +4,6 @@ import com.agmtopy.kocketmq.common.Configuration
 import com.agmtopy.kocketmq.common.concurrent.ThreadFactoryImpl
 import com.agmtopy.kocketmq.common.constant.LoggerName
 import com.agmtopy.kocketmq.common.namesrv.NamesrvConfig
-import com.agmtopy.kocketmq.common.util.FileWatchService
 import com.agmtopy.kocketmq.logging.inner.InternalLoggerFactory
 import com.agmtopy.kocketmq.logging.kvconfig.KVConfigManager
 import com.agmtopy.kocketmq.logging.processor.ClusterTestRequestProcessor
@@ -32,7 +31,6 @@ class NamesrvController(var namesrvConfig: NamesrvConfig, var nettyServerConfig:
     //延迟初始化-lateinit
     private lateinit var remotingServer: RemotingServer
     private lateinit var remotingExecutor: ExecutorService
-    private lateinit var fileWatchService: FileWatchService
 
     //默认成员变量
     private val scheduledExecutorService: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(

--- a/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/NamesrvStartup.kt
+++ b/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/NamesrvStartup.kt
@@ -5,7 +5,6 @@ import com.agmtopy.kocketmq.common.namesrv.NamesrvConfig
 import com.agmtopy.kocketmq.logging.inner.InternalLoggerFactory
 import com.agmtopy.kocketmq.remoting.RemotingCommand
 import com.agmtopy.kocketmq.remoting.netty.NettyServerConfig
-import java.lang.IllegalArgumentException
 
 /**
  * NamesrvStartup 启动类

--- a/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/NamesrvStartup.kt
+++ b/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/NamesrvStartup.kt
@@ -35,13 +35,10 @@ class NamesrvStartup {
          * 启动NamesrvController
          */
         fun start(controller: NamesrvController){
-            if (controller == null) {
-                throw IllegalArgumentException("NamesrvController is null")
-            }
-
             //NamesrvController执行初始化,如果失败时退出进程
-            if(controller.initialize()){
+            if(!controller.initialize()){
                 controller.shutdown()
+                throw IllegalStateException("Failed to initialize NamesrvController")
             }
             controller.start()
         }

--- a/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/kvconfig/KVConfigManager.kt
+++ b/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/kvconfig/KVConfigManager.kt
@@ -37,7 +37,9 @@ class KVConfigManager internal constructor(var namesrvController: NamesrvControl
                 )
                 //2. 保存配置文件
                 if (Objects.nonNull(configWrapper)) {
-                    configWrapper.getConfigTable()?.let { this.configTable.putAll(it) }
+                    configWrapper.getConfigTable()?.forEach { (namespace, table) ->
+                        this.configTable[namespace] = HashMap(table ?: emptyMap())
+                    }
                     log.info("load KV config table OK")
                 }
             }
@@ -180,9 +182,5 @@ class KVConfigManager internal constructor(var namesrvController: NamesrvControl
             log.error("printAllPeriodically InterruptedException", e)
         }
     }
-
-}
-
-private fun <K, V> HashMap<K, V>.putAll(from: Map<String?, Map<String?, String?>?>) {
 
 }

--- a/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/processor/DefaultRequestProcessor.kt
+++ b/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/processor/DefaultRequestProcessor.kt
@@ -401,9 +401,9 @@ open class DefaultRequestProcessor(namesrvController: NamesrvController) : Async
         val requestHeader: GetKVListByNamespaceRequestHeader = request.decodeCommandCustomHeader(
             GetKVListByNamespaceRequestHeader::class.java
         ) as GetKVListByNamespaceRequestHeader
-        val jsonValue: ByteArray = namesrvController.kvConfigManager.getKVListByNamespace(
+        val jsonValue: ByteArray? = namesrvController.kvConfigManager.getKVListByNamespace(
             requestHeader.namespace
-        )!!
+        )
         if (null != jsonValue) {
             response.setBody(jsonValue)
             response.code = RemotingSysResponseCode.SUCCESS

--- a/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/routeinfo/BrokerHousekeepingService.kt
+++ b/namesrv/src/main/kotlin/com/agmtopy/kocketmq/logging/routeinfo/BrokerHousekeepingService.kt
@@ -1,26 +1,35 @@
 package com.agmtopy.kocketmq.logging.routeinfo
 
+import com.agmtopy.kocketmq.common.constant.LoggerName
+import com.agmtopy.kocketmq.logging.InternalLogger
+import com.agmtopy.kocketmq.logging.inner.InternalLoggerFactory
 import com.agmtopy.kocketmq.remoting.ChannelEventListener
 import io.netty.channel.Channel
 
 /**
  * 处理Broker的链接
  */
-class BrokerHousekeepingService: ChannelEventListener {
+class BrokerHousekeepingService(
+    private val routeInfoManager: RouteInfoManager
+) : ChannelEventListener {
+    companion object {
+        private val log: InternalLogger = InternalLoggerFactory.getLogger(LoggerName.NAMESRV_LOGGER_NAME)
+    }
+
     override fun onChannelConnect(remoteAddr: String?, channel: Channel?) {
-        TODO("Not yet implemented")
+        log.info("onChannelConnect: remoteAddr={}", remoteAddr)
     }
 
     override fun onChannelClose(remoteAddr: String?, channel: Channel?) {
-        TODO("Not yet implemented")
+        routeInfoManager.onChannelDestroy(remoteAddr, channel)
     }
 
     override fun onChannelException(remoteAddr: String?, channel: Channel?) {
-        TODO("Not yet implemented")
+        routeInfoManager.onChannelDestroy(remoteAddr, channel)
     }
 
     override fun onChannelIdle(remoteAddr: String?, channel: Channel?) {
-        TODO("Not yet implemented")
+        routeInfoManager.onChannelDestroy(remoteAddr, channel)
     }
 
 }

--- a/namesrv/src/test/kotlin/com/agmtopy/kocketmq/namesrv/BrokerHousekeepingServiceTest.kt
+++ b/namesrv/src/test/kotlin/com/agmtopy/kocketmq/namesrv/BrokerHousekeepingServiceTest.kt
@@ -1,0 +1,43 @@
+package com.agmtopy.kocketmq.namesrv
+
+import com.agmtopy.kocketmq.common.MixAll
+import com.agmtopy.kocketmq.common.TopicConfig
+import com.agmtopy.kocketmq.common.protocol.body.TopicConfigSerializeWrapper
+import com.agmtopy.kocketmq.logging.routeinfo.BrokerHousekeepingService
+import com.agmtopy.kocketmq.logging.routeinfo.RouteInfoManager
+import io.netty.channel.embedded.EmbeddedChannel
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class BrokerHousekeepingServiceTest {
+
+    @Test
+    fun `should remove route data when channel is closed`() {
+        TestLoggerBootstrap.ensureRegistered()
+        val routeInfoManager = RouteInfoManager()
+        val housekeepingService = BrokerHousekeepingService(routeInfoManager)
+
+        val topicConfigWrapper = TopicConfigSerializeWrapper().apply {
+            topicConfigTable["topic-a"] = TopicConfig("topic-a")
+        }
+
+        val channel = EmbeddedChannel()
+        routeInfoManager.registerBroker(
+            "cluster-a",
+            "127.0.0.1:10911",
+            "broker-a",
+            MixAll.MASTER_ID,
+            "127.0.0.1:10912",
+            topicConfigWrapper,
+            null,
+            channel
+        )
+
+        assertNotNull(routeInfoManager.pickupTopicRouteData("topic-a"))
+
+        housekeepingService.onChannelClose("127.0.0.1:10911", channel)
+
+        assertNull(routeInfoManager.pickupTopicRouteData("topic-a"))
+    }
+}

--- a/namesrv/src/test/kotlin/com/agmtopy/kocketmq/namesrv/KVConfigManagerTest.kt
+++ b/namesrv/src/test/kotlin/com/agmtopy/kocketmq/namesrv/KVConfigManagerTest.kt
@@ -1,0 +1,40 @@
+package com.agmtopy.kocketmq.namesrv
+
+import com.agmtopy.kocketmq.common.namesrv.NamesrvConfig
+import com.agmtopy.kocketmq.common.protocol.body.KVTable
+import com.agmtopy.kocketmq.logging.NamesrvController
+import com.agmtopy.kocketmq.remoting.protocol.RemotingSerializable
+import com.agmtopy.kocketmq.remoting.netty.NettyServerConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+
+class KVConfigManagerTest {
+
+    @Test
+    fun `should put get delete and list kv configs`() {
+        TestLoggerBootstrap.ensureRegistered()
+        val tempDir = Files.createTempDirectory("kocketmq-kv")
+        val kvConfigPath = tempDir.resolve("kvConfig.json").toString()
+
+        val namesrvConfig = NamesrvConfig().apply {
+            this.kvConfigPath = kvConfigPath
+        }
+        val controller = NamesrvController(namesrvConfig, NettyServerConfig())
+
+        controller.kvConfigManager.putKVConfig("ns-test", "k1", "v1")
+        controller.kvConfigManager.putKVConfig("ns-test", "k2", "v2")
+
+        assertEquals("v1", controller.kvConfigManager.getKVConfig("ns-test", "k1"))
+        assertEquals("v2", controller.kvConfigManager.getKVConfig("ns-test", "k2"))
+
+        val body = controller.kvConfigManager.getKVListByNamespace("ns-test")
+        val table = RemotingSerializable.decode(body, KVTable::class.java)
+        assertEquals("v1", table.table["k1"])
+        assertEquals("v2", table.table["k2"])
+
+        controller.kvConfigManager.deleteKVConfig("ns-test", "k1")
+        assertNull(controller.kvConfigManager.getKVConfig("ns-test", "k1"))
+    }
+}

--- a/namesrv/src/test/kotlin/com/agmtopy/kocketmq/namesrv/TestLoggerBootstrap.kt
+++ b/namesrv/src/test/kotlin/com/agmtopy/kocketmq/namesrv/TestLoggerBootstrap.kt
@@ -1,0 +1,35 @@
+package com.agmtopy.kocketmq.namesrv
+
+import com.agmtopy.kocketmq.logging.InternalLogger
+import com.agmtopy.kocketmq.logging.inner.InternalLoggerFactory
+
+object TestLoggerBootstrap {
+    private object NoopLogger : InternalLogger {
+        override fun getName(): String = "noop"
+        override fun info(s: String) = Unit
+        override fun info(var1: String?, var2: Any?) = Unit
+        override fun info(var1: String?, var2: Any?, var3: Any?) = Unit
+        override fun warn(s: String) = Unit
+        override fun warn(s: String, e: Throwable) = Unit
+        override fun warn(var1: String?, var2: Any?) = Unit
+        override fun warn(var1: String?, var2: Any?, var3: Any?) = Unit
+        override fun debug(s: String) = Unit
+        override fun debug(var1: String?, var2: Any?) = Unit
+        override fun debug(var1: String?, var2: Any?, var3: Any?) = Unit
+        override fun error(s: String) = Unit
+        override fun error(var1: String?, var2: Any?) = Unit
+        override fun error(var1: String?, var2: Any?, var3: Any?) = Unit
+    }
+
+    private class NoopLoggerFactory : InternalLoggerFactory() {
+        override fun getLoggerInstance(name: String): InternalLogger = NoopLogger
+        override fun getLoggerType(): String = LOGGER_SLF4J
+        override fun shutdown() = Unit
+    }
+
+    fun ensureRegistered() {
+        if (!InternalLoggerFactory.loggerFactoryCache.containsKey(InternalLoggerFactory.DEFAULT_LOGGER)) {
+            InternalLoggerFactory.loggerFactoryCache[InternalLoggerFactory.DEFAULT_LOGGER] = NoopLoggerFactory()
+        }
+    }
+}

--- a/remoting/build.gradle
+++ b/remoting/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'kotlin'
 }
 
 group 'com.agmtopy'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,7 @@
 pluginManagement {
     repositories {
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
+        gradlePluginPortal()
         mavenCentral()
-        maven { url 'https://plugins.gradle.org/m2/' }
     }
 }
 rootProject.name = 'kocketmq'
@@ -10,4 +9,3 @@ include 'namesrv'
 include 'logging'
 include 'common'
 include 'remoting'
-


### PR DESCRIPTION
### Motivation
- Finish incomplete `namesrv` behaviour so the NameServer module can initialize, start and shutdown correctly and be unit-tested. 
- Ensure route cleanup works on broker channel events and KV config persists/loads reliably. 
- Make the project buildable/testable with modern Gradle/Kotlin and avoid logger initialization blocking tests.

### Description
- Implemented core lifecycle in `NamesrvController`: `initialize()` now returns `true` on success, `start()` starts the `RemotingServer`, and `shutdown()` cleanly shuts down remoting, executors and scheduled tasks. 
- Implemented `BrokerHousekeepingService` to log connects and call `RouteInfoManager.onChannelDestroy` on close/exception/idle to remove broker route state. 
- Fixed `KVConfigManager.load()` to properly populate `configTable` from `KVConfigSerializeWrapper` (removed broken extension helper) and preserved persist logic. 
- Made `DefaultRequestProcessor#getKVListByNamespace` null-safe by avoiding forced non-null unwrapping. 
- Corrected `NamesrvStartup.start` to throw and shutdown when initialization fails. 
- Added tests and test bootstrap: `KVConfigManagerTest`, `BrokerHousekeepingServiceTest`, and `TestLoggerBootstrap` (no-op logger factory) to avoid logger init failures in tests. 
- Gradle/Kotlin compatibility adjustments: upgraded Kotlin plugin to `1.9.24`, set Kotlin `jvmTarget = "11"` for subprojects, added `sourceCompatibility = 11` and JUnit 5 (`useJUnitPlatform()`) in `namesrv` module.

### Testing
- Ran unit tests with `gradle :namesrv:test --no-daemon` using Java 17 toolchain; the `namesrv` test suite executed and all newly added tests passed. 
- The `:namesrv:test` build completed successfully after applying the Kotlin/Gradle jvm-target fixes and test bootstrap (no other failing automated tests remained).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b324e2284832e8e87fbddcfe0e2af)